### PR TITLE
Fix crash on Mac OS with fieldnames longer than 7 characters

### DIFF
--- a/judy.rb
+++ b/judy.rb
@@ -5,6 +5,7 @@ class Judy < Formula
   sha256 "d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"
 
   def install
+    ENV['CFLAGS'] = "-O2 -D_FORTIFY_SOURCE=0"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     ENV.deparallelize # Doesn't compile on parallel build


### PR DESCRIPTION
On Mac OS, strcpy under the hood calls `__strcpy_chk` which attempts
to check if the destination is large enough to fit the input. Due to
how the `SHORTCUTLEAF` struct is defined in `JudySL.c`, `__strcpy_chk`
believes it can only fit `sizeof(WORDSIZE)`, while it is actually a
variable-sized field.

This change passes `_FORTIFY_SOURCE=0` to clang, which ensures
`__strcpy_chk` is *not* inserted.

Fixes https://github.com/traildb/traildb/issues/136